### PR TITLE
Add HSTS header regardless of status code

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -260,7 +260,7 @@ server {
 	{{ end }}
 
 	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
-	add_header Strict-Transport-Security "{{ trim $hsts }}";
+	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}


### PR DESCRIPTION
See nginx [doc](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) and [blog](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/).